### PR TITLE
Change "touchstart" event handling

### DIFF
--- a/touchscroll.js
+++ b/touchscroll.js
@@ -15,7 +15,7 @@
 
 			document.getElementById(id).addEventListener("touchstart", function(event) {
 				scrollStartPos=this.scrollTop+event.touches[0].pageY;
-				event.preventDefault();
+				event.stopPropagation();
 			},false);
 
 			document.getElementById(id).addEventListener("touchmove", function(event) {


### PR DESCRIPTION
I have found in my applications that when I have a link or button within the scrollable div that `event.preventDefault` disables these. However, if I instead make it `event.stopPropagation` then the links and buttons work but the event is still not bubbled up above the element that you want scrolled.
